### PR TITLE
fix for findOne with specification method not found

### DIFF
--- a/libs/core/src/main/java/com/sourcefuse/jarc/core/repositories/SoftDeletesRepository.java
+++ b/libs/core/src/main/java/com/sourcefuse/jarc/core/repositories/SoftDeletesRepository.java
@@ -1,24 +1,26 @@
 package com.sourcefuse.jarc.core.repositories;
 
-import com.sourcefuse.jarc.core.models.base.SoftDeleteEntity;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+import com.sourcefuse.jarc.core.models.base.SoftDeleteEntity;
 
 @NoRepositoryBean
 public interface SoftDeletesRepository<
   T extends SoftDeleteEntity, E extends Serializable
 >
-  extends JpaRepository<T, E> {
+  extends JpaRepositoryImplementation<T, E> {
   void deleteByIdHard(E id);
 
   void deleteHard(T entity);


### PR DESCRIPTION
## Description
fix for findOne with specification method not found

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
